### PR TITLE
Feat-2 jwt를 통한 인증 및 인가

### DIFF
--- a/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
@@ -1,9 +1,6 @@
 package com.project.snsserver.domain.member.controller;
 
-import com.project.snsserver.domain.member.model.dto.SendAuthCodeRequest;
-import com.project.snsserver.domain.member.model.dto.SignUpRequest;
-import com.project.snsserver.domain.member.model.dto.SignUpResponse;
-import com.project.snsserver.domain.member.model.dto.VerifyAuthCodeRequest;
+import com.project.snsserver.domain.member.model.dto.*;
 import com.project.snsserver.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -78,5 +75,16 @@ public class MemberController {
 
         SignUpResponse response = memberService.signUp(file, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 회원 로그인
+     */
+    @Operation(summary = "회원 로그인")
+    @PostMapping("/auth/login")
+    public ResponseEntity<LoginResponse> login (@RequestBody @Valid LoginRequest request) {
+
+        LoginResponse response = memberService.login(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
@@ -87,4 +87,15 @@ public class MemberController {
         LoginResponse response = memberService.login(request);
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * access token 재발급
+     */
+    @Operation(summary = "회원 access token 재발급")
+    @PostMapping("/auth/token")
+    public ResponseEntity<ReissueTokenResponse> reissueAccessToken(@RequestBody ReissueTokenRequest request) {
+
+        ReissueTokenResponse response = memberService.reissueAccessToken(request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
@@ -2,11 +2,13 @@ package com.project.snsserver.domain.member.controller;
 
 import com.project.snsserver.domain.member.model.dto.*;
 import com.project.snsserver.domain.member.service.MemberService;
+import com.project.snsserver.domain.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -96,6 +98,18 @@ public class MemberController {
     public ResponseEntity<ReissueTokenResponse> reissueAccessToken(@RequestBody ReissueTokenRequest request) {
 
         ReissueTokenResponse response = memberService.reissueAccessToken(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 회원 로그아웃
+     */
+    @Operation(summary = "회원 로그아웃")
+    @PostMapping("/auth/logout")
+    public ResponseEntity<Map<String, String>> logout(@RequestBody LogoutRequest request,
+                                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Map<String, String> response = memberService.logout(request, userDetails.getUsername());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/LoginRequest.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/LoginRequest.java
@@ -1,0 +1,21 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/LoginResponse.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/LoginResponse.java
@@ -1,0 +1,17 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginResponse {
+
+    private String accessToken;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/LogoutRequest.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/LogoutRequest.java
@@ -1,0 +1,15 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LogoutRequest {
+
+    private String accessToken;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/ReissueTokenRequest.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/ReissueTokenRequest.java
@@ -1,0 +1,15 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReissueTokenRequest {
+
+    private String refreshToken;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/ReissueTokenResponse.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/ReissueTokenResponse.java
@@ -1,0 +1,15 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReissueTokenResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/entity/LogoutAccessToken.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/entity/LogoutAccessToken.java
@@ -1,0 +1,23 @@
+package com.project.snsserver.domain.member.model.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@Builder
+@RedisHash("LogoutAccessToken")
+public class LogoutAccessToken {
+
+    @Id
+    private String id; // access token
+
+    private String email;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long expiration;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/entity/Member.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/entity/Member.java
@@ -3,6 +3,7 @@ package com.project.snsserver.domain.member.model.entity;
 import com.project.snsserver.domain.member.type.Gender;
 import com.project.snsserver.domain.member.type.MemberRole;
 import com.project.snsserver.domain.member.type.MemberStatus;
+import com.project.snsserver.global.entity.BaseTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @Column(name = "member_id")

--- a/src/main/java/com/project/snsserver/domain/member/model/entity/MemberAuthCode.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/entity/MemberAuthCode.java
@@ -19,5 +19,5 @@ public class MemberAuthCode {
     private String email;
 
     @TimeToLive(unit = TimeUnit.MILLISECONDS)
-    private Long expiredAt;
+    private Long expiration;
 }

--- a/src/main/java/com/project/snsserver/domain/member/model/entity/RefreshToken.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/entity/RefreshToken.java
@@ -1,0 +1,23 @@
+package com.project.snsserver.domain.member.model.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@Builder
+@RedisHash("RefreshToken")
+public class RefreshToken {
+
+    @Id
+    private String id; // email
+
+    private String refreshToken;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long expiredAt;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/entity/RefreshToken.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/entity/RefreshToken.java
@@ -19,5 +19,5 @@ public class RefreshToken {
     private String refreshToken;
 
     @TimeToLive(unit = TimeUnit.MILLISECONDS)
-    private Long expiredAt;
+    private Long expiration;
 }

--- a/src/main/java/com/project/snsserver/domain/member/repository/jpa/MemberRepository.java
+++ b/src/main/java/com/project/snsserver/domain/member/repository/jpa/MemberRepository.java
@@ -3,9 +3,13 @@ package com.project.snsserver.domain.member.repository.jpa;
 import com.project.snsserver.domain.member.model.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/project/snsserver/domain/member/repository/redis/LogoutAccessTokenRepository.java
+++ b/src/main/java/com/project/snsserver/domain/member/repository/redis/LogoutAccessTokenRepository.java
@@ -1,0 +1,7 @@
+package com.project.snsserver.domain.member.repository.redis;
+
+import com.project.snsserver.domain.member.model.entity.LogoutAccessToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface LogoutAccessTokenRepository extends CrudRepository<LogoutAccessToken, String> {
+}

--- a/src/main/java/com/project/snsserver/domain/member/repository/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/project/snsserver/domain/member/repository/redis/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.project.snsserver.domain.member.repository.redis;
+
+import com.project.snsserver.domain.member.model.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
@@ -41,4 +41,9 @@ public interface MemberService {
      * access token 재발급
      */
     ReissueTokenResponse reissueAccessToken(ReissueTokenRequest request);
+
+    /**
+     * 회원 로그아웃
+     */
+    Map<String, String> logout(LogoutRequest request, String email);
 }

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
@@ -1,8 +1,6 @@
 package com.project.snsserver.domain.member.service;
 
-import com.project.snsserver.domain.member.model.dto.SignUpRequest;
-import com.project.snsserver.domain.member.model.dto.SignUpResponse;
-import com.project.snsserver.domain.member.model.dto.VerifyAuthCodeRequest;
+import com.project.snsserver.domain.member.model.dto.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
@@ -33,4 +31,9 @@ public interface MemberService {
      * 회원 가입
      */
     SignUpResponse signUp(MultipartFile file, SignUpRequest request);
+
+    /**
+     * 회원 로그인
+     */
+    LoginResponse login(LoginRequest request);
 }

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
@@ -36,4 +36,9 @@ public interface MemberService {
      * 회원 로그인
      */
     LoginResponse login(LoginRequest request);
+
+    /**
+     * access token 재발급
+     */
+    ReissueTokenResponse reissueAccessToken(ReissueTokenRequest request);
 }

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
@@ -84,7 +84,7 @@ public class MemberServiceImpl implements MemberService {
         MemberAuthCode code = MemberAuthCode.builder()
                 .id(authCode)
                 .email(email)
-                .expiredAt(1000L * 60 * 3)
+                .expiration(1000L * 60 * 3)
                 .build();
 
         memberAuthCodeRepository.save(code);

--- a/src/main/java/com/project/snsserver/domain/security/CustomUserDetails.java
+++ b/src/main/java/com/project/snsserver/domain/security/CustomUserDetails.java
@@ -1,0 +1,75 @@
+package com.project.snsserver.domain.security;
+
+import com.project.snsserver.domain.member.model.entity.Member;
+import com.project.snsserver.domain.member.type.MemberRole;
+import com.project.snsserver.domain.member.type.MemberStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private String username;
+
+    private String password;
+
+    private MemberRole role;
+
+    private Member member;
+
+
+    public CustomUserDetails(Member member) {
+        this.username = member.getEmail();
+        this.password = member.getPassword();
+        this.member = member;
+        this.role = member.getRole();
+    }
+
+    // 계정의 권한 목록
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(role.getValue()));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    // 계정의 만료 여부
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    // 계정의 잠금 여부
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    // 비밀번호 만료 여부
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    // 계정의 활성화 여부
+    @Override
+    public boolean isEnabled() {
+        return Objects.equals(MemberStatus.ACTIVE, member.getStatus());
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/project/snsserver/domain/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,47 @@
+package com.project.snsserver.domain.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.snsserver.global.error.model.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.project.snsserver.global.error.type.MemberErrorCode.FAIL_TO_AUTHORIZATION;
+
+/**
+ * AccessDeniedException 처리
+ * 권한이 없는 경우
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        log.error(accessDeniedException.getMessage());
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+
+        ErrorResponse<String> errorResponse = ErrorResponse.<String>builder()
+                .status(FAIL_TO_AUTHORIZATION.getStatus().value())
+                .code(FAIL_TO_AUTHORIZATION.getCode())
+                .message(FAIL_TO_AUTHORIZATION.getMessage())
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/snsserver/domain/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package com.project.snsserver.domain.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.snsserver.global.error.model.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.project.snsserver.global.error.type.MemberErrorCode.FAIL_TO_AUTHENTICATION;
+
+/**
+ * AuthenticationException 처리
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        log.error(authException.getMessage());
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        ErrorResponse<String> errorResponse = ErrorResponse.<String>builder()
+                .status(FAIL_TO_AUTHENTICATION.getStatus().value())
+                .code(FAIL_TO_AUTHENTICATION.getCode())
+                .message(FAIL_TO_AUTHENTICATION.getMessage())
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/snsserver/domain/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.project.snsserver.domain.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * access token 유효한지 검증
+ * 검증 성공 시 Security Context에 Authentication 객체 저장
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String[] EXCLUDED_URL
+            = {"/api/v1/members/sign-up", "/api/v1/members/auth/login",
+            "/api/v1/members/duplicate/email", "/api/v1/members/duplicate/nickname",
+            "/h2-console", "/swagger-ui", "/api-docs"};
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * filter 동작 제외
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return Arrays.stream(EXCLUDED_URL).anyMatch(request.getRequestURI()::startsWith);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // header에서 access token 추출
+        log.info("resolve access token from header");
+        String token = jwtTokenProvider.resolveToken(request);
+        // access token 유효성 검증
+        if (!Objects.isNull(token) && jwtTokenProvider.validateAccessToken(token)) {
+            log.info("access token is valid");
+
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/snsserver/domain/security/jwt/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String[] EXCLUDED_URL
-            = {"/api/v1/members/sign-up", "/api/v1/members/auth/login",
+            = {"/api/v1/members/sign-up", "/api/v1/members/auth/login", "/api/v1/members/auth/token",
             "/api/v1/members/duplicate/email", "/api/v1/members/duplicate/nickname",
             "/h2-console", "/swagger-ui", "/api-docs"};
 

--- a/src/main/java/com/project/snsserver/domain/security/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/project/snsserver/domain/security/jwt/JwtExceptionFilter.java
@@ -1,0 +1,52 @@
+package com.project.snsserver.domain.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.snsserver.global.error.exception.CustomJwtException;
+import com.project.snsserver.global.error.model.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * jwt 관련 예외 처리
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CustomJwtException e) {
+            setErrorResponse(response, e);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, CustomJwtException e) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(e.getErrorCode().getStatus().value());
+
+        ErrorResponse<String> errorResponse = ErrorResponse.<String>builder()
+                .status(e.getErrorCode().getStatus().value())
+                .code(e.getErrorCode().getCode())
+                .message(e.getMessage())
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package com.project.snsserver.domain.security.jwt;
 
+import com.project.snsserver.domain.member.model.entity.RefreshToken;
+import com.project.snsserver.domain.member.repository.redis.RefreshTokenRepository;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -25,6 +27,8 @@ public class JwtTokenProvider {
 
     @Value("${spring.jwt.valid.refreshToken}")
     private Long refreshTokenValid;
+
+    private final RefreshTokenRepository refreshTokenRepository;
 
 
     private Key getKey() {
@@ -68,6 +72,22 @@ public class JwtTokenProvider {
         Map<String, Object> claims = new HashMap<>();
         claims.put("email", email);
 
-        return generateToken(claims, refreshTokenValid);
+        String refreshToken = generateToken(claims, refreshTokenValid);
+        saveRefreshToken(email, refreshToken);
+        return refreshToken;
+    }
+
+    /**
+     * refresh token redis 저장
+     */
+    public void saveRefreshToken(String email, String token) {
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .id(email)
+                .refreshToken(token)
+                .expiredAt(refreshTokenValid)
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
     }
 }

--- a/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
@@ -100,7 +100,7 @@ public class JwtTokenProvider {
         RefreshToken refreshToken = RefreshToken.builder()
                 .id(email)
                 .refreshToken(token)
-                .expiredAt(refreshTokenValid)
+                .expiration(refreshTokenValid)
                 .build();
 
         refreshTokenRepository.save(refreshToken);

--- a/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
@@ -2,22 +2,36 @@ package com.project.snsserver.domain.security.jwt;
 
 import com.project.snsserver.domain.member.model.entity.RefreshToken;
 import com.project.snsserver.domain.member.repository.redis.RefreshTokenRepository;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import com.project.snsserver.domain.security.service.CustomUserDetailsService;
+import com.project.snsserver.global.error.exception.CustomJwtException;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
+import javax.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.project.snsserver.global.error.type.JwtErrorCode.*;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
 
     @Value("${spring.jwt.secret}")
     private String secretKey;
@@ -29,6 +43,7 @@ public class JwtTokenProvider {
     private Long refreshTokenValid;
 
     private final RefreshTokenRepository refreshTokenRepository;
+    private final CustomUserDetailsService userDetailsService;
 
 
     private Key getKey() {
@@ -89,5 +104,57 @@ public class JwtTokenProvider {
                 .build();
 
         refreshTokenRepository.save(refreshToken);
+    }
+
+    /**
+     * request header에서 access token 추출
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String headerAuth = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(headerAuth) && headerAuth.startsWith(BEARER_PREFIX)) {
+            return headerAuth.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    /**
+     * access token 유효성 검증
+     */
+    public boolean validateAccessToken(String token) {
+        return !extractClaims(token).getExpiration().before(new Date());
+    }
+
+    public Claims extractClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            log.error(e.getMessage());
+            throw new CustomJwtException(EXPIRED_TOKEN);
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error(e.getMessage());
+            throw new CustomJwtException(INVALID_TOKEN_SIGNATURE);
+        } catch (UnsupportedJwtException e) {
+            log.error(e.getMessage());
+            throw new CustomJwtException(UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            throw new CustomJwtException(INCORRECT_TOKEN);
+        }
+    }
+
+    public String extractUsername(String token) {
+        Claims claims = extractClaims(token);
+        return claims.get("email", String.class);
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails
+                = userDetailsService.loadUserByUsername(extractUsername(token));
+
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
@@ -124,6 +124,17 @@ public class JwtTokenProvider {
         return !extractClaims(token).getExpiration().before(new Date());
     }
 
+    /**
+     * refresh token 유효성 검증
+     */
+    public boolean validateRefreshToken(String token) {
+        try {
+            return !extractClaims(token).getExpiration().before(new Date());
+        } catch (CustomJwtException e) {
+            return false;
+        }
+    }
+
     public Claims extractClaims(String token) {
         try {
             return Jwts.parserBuilder()

--- a/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/snsserver/domain/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,73 @@
+package com.project.snsserver.domain.security.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    @Value("${spring.jwt.valid.accessToken}")
+    private Long accessTokenValid;
+
+    @Value("${spring.jwt.valid.refreshToken}")
+    private Long refreshTokenValid;
+
+
+    private Key getKey() {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+
+    public String generateToken(Map<String, Object> claims, long expireTime) {
+
+        Map<String, Object> header = new HashMap<>();
+        header.put("typ", "JWT");
+        header.put("alg", "HS256");
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeader(header)
+                .setSubject("AUTH")
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expireTime))
+                .signWith(getKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * access token 발급
+     */
+    public String generateAccessToken(String email, String role) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("email", email);
+        claims.put("role", role);
+
+        return generateToken(claims, accessTokenValid);
+    }
+
+    /**
+     * refresh token 발급
+     */
+    public String generateRefreshToken(String email) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("email", email);
+
+        return generateToken(claims, refreshTokenValid);
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/project/snsserver/domain/security/service/CustomUserDetailsService.java
@@ -1,0 +1,34 @@
+package com.project.snsserver.domain.security.service;
+
+import com.project.snsserver.domain.member.model.entity.Member;
+import com.project.snsserver.domain.member.repository.jpa.MemberRepository;
+import com.project.snsserver.domain.security.CustomUserDetails;
+import com.project.snsserver.global.error.exception.MemberException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import static com.project.snsserver.global.error.type.MemberErrorCode.MEMBER_NOT_FOUND;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        log.info("loadUserByUsername method call");
+
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/java/com/project/snsserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/snsserver/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.project.snsserver.global.config;
 
+import com.project.snsserver.domain.security.handler.CustomAccessDeniedHandler;
 import com.project.snsserver.domain.security.handler.CustomAuthenticationEntryPoint;
 import com.project.snsserver.domain.security.jwt.JwtAuthenticationFilter;
 import com.project.snsserver.domain.security.jwt.JwtExceptionFilter;
@@ -17,14 +18,17 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsUtils;
 
+import static com.project.snsserver.domain.member.type.MemberRole.ADMIN;
+
 @Configuration
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -54,10 +58,12 @@ public class SecurityConfig {
                 .antMatchers("/swagger-ui/**", "/h2-console/**", "/api-docs/**",
                         "/api/v1/members/sign-up", "/api/v1/members/auth/**",
                         "/api/v1/members/duplicate/**").permitAll()
+                .antMatchers("/api/v1/admin/**").hasAuthority(ADMIN.getValue())
                 .anyRequest().authenticated();
 
         http.exceptionHandling()
                 .authenticationEntryPoint(authenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler)
 
                 .and()
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/project/snsserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/snsserver/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.project.snsserver.global.config;
 
+import com.project.snsserver.domain.security.handler.CustomAuthenticationEntryPoint;
 import com.project.snsserver.domain.security.jwt.JwtAuthenticationFilter;
 import com.project.snsserver.domain.security.jwt.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
@@ -17,12 +18,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsUtils;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -54,7 +56,10 @@ public class SecurityConfig {
                         "/api/v1/members/duplicate/**").permitAll()
                 .anyRequest().authenticated();
 
-        http
+        http.exceptionHandling()
+                .authenticationEntryPoint(authenticationEntryPoint)
+
+                .and()
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 

--- a/src/main/java/com/project/snsserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/snsserver/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.project.snsserver.global.config;
 
 import com.project.snsserver.domain.security.jwt.JwtAuthenticationFilter;
+import com.project.snsserver.domain.security.jwt.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +22,7 @@ import org.springframework.web.cors.CorsUtils;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -53,7 +55,8 @@ public class SecurityConfig {
                 .anyRequest().authenticated();
 
         http
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/project/snsserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/snsserver/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.project.snsserver.global.config;
 
+import com.project.snsserver.domain.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,12 +12,15 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsUtils;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -35,6 +39,7 @@ public class SecurityConfig {
                 .csrf().disable();
 
         http.formLogin().disable();
+        http.logout().disable();
 
         http.headers().frameOptions().sameOrigin();
 
@@ -42,7 +47,13 @@ public class SecurityConfig {
 
         http.authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                .antMatchers("/api/v1/**", "/h2-console").permitAll();
+                .antMatchers("/swagger-ui/**", "/h2-console/**", "/api-docs/**",
+                        "/api/v1/members/sign-up", "/api/v1/members/auth/**",
+                        "/api/v1/members/duplicate/**").permitAll()
+                .anyRequest().authenticated();
+
+        http
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/project/snsserver/global/error/exception/CustomJwtException.java
+++ b/src/main/java/com/project/snsserver/global/error/exception/CustomJwtException.java
@@ -1,0 +1,15 @@
+package com.project.snsserver.global.error.exception;
+
+import com.project.snsserver.global.error.type.JwtErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomJwtException extends RuntimeException {
+
+    private final JwtErrorCode errorCode;
+
+    public CustomJwtException (JwtErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/project/snsserver/global/error/type/JwtErrorCode.java
+++ b/src/main/java/com/project/snsserver/global/error/type/JwtErrorCode.java
@@ -1,0 +1,26 @@
+package com.project.snsserver.global.error.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * jwt 관련된 예외 CODE = E301 ~ E399
+ */
+
+@Getter
+@AllArgsConstructor
+public enum JwtErrorCode {
+
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "E301", "만료된 token 입니다."),
+
+    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "E302", "유효하지 않은 token 서명입니다."),
+
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "E303", "지원되지 않는 token 입니다."),
+
+    INCORRECT_TOKEN(HttpStatus.UNAUTHORIZED, "E304", "잘못된 token 입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/snsserver/global/error/type/JwtErrorCode.java
+++ b/src/main/java/com/project/snsserver/global/error/type/JwtErrorCode.java
@@ -18,7 +18,9 @@ public enum JwtErrorCode {
 
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "E303", "지원되지 않는 token 입니다."),
 
-    INCORRECT_TOKEN(HttpStatus.UNAUTHORIZED, "E304", "잘못된 token 입니다.");
+    INCORRECT_TOKEN(HttpStatus.UNAUTHORIZED, "E304", "잘못된 token 입니다."),
+
+    ALREADY_LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "E305", "이미 로그아웃한 회원입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
+++ b/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
@@ -17,7 +17,8 @@ public enum MemberErrorCode {
     FAIL_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E103", "이메일 전송에 실패하였습니다."),
     INCORRECT_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "E104", "메일 인증번호가 일치하지 않습니다."),
     INCORRECT_PASSWORD_CHECK(HttpStatus.BAD_REQUEST, "E105", "비밀번호와 동일하지 않습니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E106", "존재하지 않는 회원입니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E106", "존재하지 않는 회원입니다."),
+    FAIL_TO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "E107", "사용자 인증에 실패하였습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
+++ b/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
@@ -19,8 +19,8 @@ public enum MemberErrorCode {
     INCORRECT_PASSWORD_CHECK(HttpStatus.BAD_REQUEST, "E105", "비밀번호와 동일하지 않습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E106", "존재하지 않는 회원입니다."),
     FAIL_TO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "E107", "사용자 인증에 실패하였습니다."),
-    FAIL_TO_AUTHORIZATION(HttpStatus.FORBIDDEN, "E108", "사용자 권한이 없습니다.");
-
+    FAIL_TO_AUTHORIZATION(HttpStatus.FORBIDDEN, "E108", "사용자 권한이 없습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "E109", "refresh token이 유효하지 않습니다.");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
+++ b/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
@@ -16,7 +16,8 @@ public enum MemberErrorCode {
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "E102", "이미 존재하는 닉네임입니다."),
     FAIL_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E103", "이메일 전송에 실패하였습니다."),
     INCORRECT_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "E104", "메일 인증번호가 일치하지 않습니다."),
-    INCORRECT_PASSWORD_CHECK(HttpStatus.BAD_REQUEST, "E105", "비밀번호와 동일하지 않습니다.");
+    INCORRECT_PASSWORD_CHECK(HttpStatus.BAD_REQUEST, "E105", "비밀번호와 동일하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E106", "존재하지 않는 회원입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
+++ b/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
@@ -18,7 +18,8 @@ public enum MemberErrorCode {
     INCORRECT_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "E104", "메일 인증번호가 일치하지 않습니다."),
     INCORRECT_PASSWORD_CHECK(HttpStatus.BAD_REQUEST, "E105", "비밀번호와 동일하지 않습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E106", "존재하지 않는 회원입니다."),
-    FAIL_TO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "E107", "사용자 인증에 실패하였습니다.");
+    FAIL_TO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "E107", "사용자 인증에 실패하였습니다."),
+    FAIL_TO_AUTHORIZATION(HttpStatus.FORBIDDEN, "E108", "사용자 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
- 로그인 성공 시 access token과 refresh token 발급
- refresh token을 통해 access token 재발급
- 로그아웃 시 redis에 로그아웃 여부를 알 수 있도록 저장
- access token 검증 시 jwt에 대한 예외 처리 로직 분리

📌 **추후 개선**
refresh token 발급 시 http only cookie에 저장할 수 있도록 할 예정