### PR TITLE
Refactor-1 jpa 게시물 삭제 시 이미지 및 좋아요 일괄 삭제

### DIFF
--- a/src/main/java/com/project/snsserver/domain/board/model/dto/CommentResponse.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/dto/CommentResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -20,14 +20,14 @@ public class CommentResponse {
 
     private String nickname;
 
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     public static CommentResponse fromEntity(Comment comment) {
         return CommentResponse.builder()
                 .commentId(comment.getId())
                 .content(comment.getContent())
                 .nickname(comment.getMember().getNickname())
-                .createdAt(Timestamp.valueOf(comment.getCreatedAt()))
+                .createdAt(comment.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/model/dto/EditCommentResponse.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/dto/EditCommentResponse.java
@@ -6,9 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.Objects;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -22,18 +20,14 @@ public class EditCommentResponse {
 
     private String nickname;
 
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     public static EditCommentResponse fromEntity(Comment comment) {
         return EditCommentResponse.builder()
                 .commentId(comment.getId())
                 .content(comment.getContent())
                 .nickname(comment.getMember().getNickname())
-                .createdAt(
-                        Objects.isNull(comment.getCreatedAt()) ?
-                                Timestamp.from(Instant.MIN)
-                                : Timestamp.valueOf(comment.getCreatedAt())
-                )
+                .createdAt(comment.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/model/dto/EditPostResponse.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/dto/EditPostResponse.java
@@ -6,10 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Timestamp;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 @Getter
 @Builder
@@ -27,7 +25,7 @@ public class EditPostResponse {
 
     private List<PostImageResponse> postImages;
 
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     public static EditPostResponse fromEntity(Post post, List<PostImageResponse> postImages) {
         return EditPostResponse.builder()
@@ -36,11 +34,7 @@ public class EditPostResponse {
                 .content(post.getContent())
                 .nickname(post.getMember().getNickname())
                 .postImages(postImages)
-                .createdAt(
-                        Objects.isNull(post.getCreatedAt()) ?
-                        Timestamp.from(Instant.MIN)
-                        : Timestamp.valueOf(post.getCreatedAt())
-                )
+                .createdAt(post.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/model/dto/PostImageResponse.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/dto/PostImageResponse.java
@@ -6,9 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.Objects;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -20,17 +18,13 @@ public class PostImageResponse {
 
     private String postImageUrl;
 
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     public static PostImageResponse fromEntity(PostImage postImage) {
         return PostImageResponse.builder()
                 .postImageId(postImage.getId())
                 .postImageUrl(postImage.getPostImageUrl())
-                .createdAt(
-                        Objects.isNull(postImage.getCreatedAt()) ?
-                                Timestamp.from(Instant.MIN)
-                                : Timestamp.valueOf(postImage.getCreatedAt())
-                )
+                .createdAt(postImage.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/model/dto/PostResponse.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/dto/PostResponse.java
@@ -1,13 +1,11 @@
 package com.project.snsserver.domain.board.model.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,7 +19,7 @@ public class PostResponse {
 
     private String nickname;
 
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     private Long commentCnt;
 

--- a/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
@@ -31,7 +31,7 @@ public class Post extends BaseTimeEntity {
     private Member member;
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
     private List<PostImage> postImages = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
@@ -35,7 +35,7 @@ public class Post extends BaseTimeEntity {
     private List<PostImage> postImages = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
     private List<Comment> comments = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
@@ -39,7 +39,7 @@ public class Post extends BaseTimeEntity {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
     private List<PostHeart> hearts = new ArrayList<>();
 
 

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomCommentRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomCommentRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.domain.Slice;
 public interface CustomCommentRepository {
 
     Slice<CommentResponse> findCommentAllByPostId(Long postId, Long lastCommentId, Pageable pageable);
+
+    Long deleteCommentAllByPostId(Long postId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHeartRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHeartRepository.java
@@ -1,0 +1,6 @@
+package com.project.snsserver.domain.board.repository.jpa;
+
+public interface CustomPostHeartRepository {
+
+    Long deletePostHeartAllByPostId(Long postId);
+}

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostImageRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostImageRepository.java
@@ -1,0 +1,6 @@
+package com.project.snsserver.domain.board.repository.jpa;
+
+public interface CustomPostImageRepository {
+
+    Long deleteAllPostImageByPostId(Long postId);
+}

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/PostHeartRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/PostHeartRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface PostHeartRepository extends JpaRepository<PostHeart, Long> {
+public interface PostHeartRepository extends JpaRepository<PostHeart, Long>, CustomPostHeartRepository {
 
     boolean existsByPostAndMember(Post post, Member member);
 

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/PostImageRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/PostImageRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+public interface PostImageRepository extends JpaRepository<PostImage, Long>, CustomPostImageRepository {
 
     List<PostImage> findAllByPost(Post post);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomCommentRepositoryImpl.java
@@ -42,6 +42,16 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
         return checkLastPage(pageable, comments);
     }
 
+    /**
+     * 특정 게시물의 댓글 전체 삭제
+     */
+    @Override
+    public Long deleteCommentAllByPostId(Long postId) {
+        return queryFactory.delete(comment)
+                .where(comment.post.id.eq(postId))
+                .execute();
+    }
+
     private BooleanExpression lastCommentId(Long lastCommentId) {
         if (lastCommentId == null) {
             return null;

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHeartRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHeartRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.project.snsserver.domain.board.repository.jpa.impl;
+
+import com.project.snsserver.domain.board.repository.jpa.CustomPostHeartRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.project.snsserver.domain.board.model.entity.QPostHeart.postHeart;
+
+@RequiredArgsConstructor
+public class CustomPostHeartRepositoryImpl implements CustomPostHeartRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Long deletePostHeartAllByPostId(Long postId) {
+        return queryFactory.delete(postHeart)
+                .where(postHeart.post.id.eq(postId))
+                .execute();
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostImageRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostImageRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.project.snsserver.domain.board.repository.jpa.impl;
+
+import com.project.snsserver.domain.board.repository.jpa.CustomPostImageRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.project.snsserver.domain.board.model.entity.QPostImage.postImage;
+
+@RequiredArgsConstructor
+public class CustomPostImageRepositoryImpl implements CustomPostImageRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Long deleteAllPostImageByPostId(Long postId) {
+        return queryFactory.delete(postImage)
+                .where(postImage.post.id.eq(postId))
+                .execute();
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
@@ -7,6 +7,7 @@ import com.project.snsserver.domain.board.model.dto.PostImageResponse;
 import com.project.snsserver.domain.board.model.dto.PostResponse;
 import com.project.snsserver.domain.board.model.entity.Post;
 import com.project.snsserver.domain.board.model.entity.PostImage;
+import com.project.snsserver.domain.board.repository.jpa.CommentRepository;
 import com.project.snsserver.domain.board.repository.jpa.PostImageRepository;
 import com.project.snsserver.domain.board.repository.jpa.PostRepository;
 import com.project.snsserver.domain.member.model.entity.Member;
@@ -32,6 +33,7 @@ public class PostServiceImpl implements PostService {
     private final AwsS3Service awsS3Service;
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
+    private final CommentRepository commentRepository;
 
     @Override
     @Transactional
@@ -105,6 +107,7 @@ public class PostServiceImpl implements PostService {
             postImages.forEach((postImage -> awsS3Service.deleteFile(postImage.getPostImageUrl(), DIR)));
         }
 
+        commentRepository.deleteCommentAllByPostId(postId);
         postRepository.delete(post);
         return getMessage("게시물이 삭제되었습니다.");
     }

--- a/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
@@ -8,6 +8,7 @@ import com.project.snsserver.domain.board.model.dto.PostResponse;
 import com.project.snsserver.domain.board.model.entity.Post;
 import com.project.snsserver.domain.board.model.entity.PostImage;
 import com.project.snsserver.domain.board.repository.jpa.CommentRepository;
+import com.project.snsserver.domain.board.repository.jpa.PostHeartRepository;
 import com.project.snsserver.domain.board.repository.jpa.PostImageRepository;
 import com.project.snsserver.domain.board.repository.jpa.PostRepository;
 import com.project.snsserver.domain.member.model.entity.Member;
@@ -34,6 +35,7 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
     private final CommentRepository commentRepository;
+    private final PostHeartRepository postHeartRepository;
 
     @Override
     @Transactional
@@ -108,6 +110,8 @@ public class PostServiceImpl implements PostService {
         }
 
         commentRepository.deleteCommentAllByPostId(postId);
+        postHeartRepository.deletePostHeartAllByPostId(postId);
+
         postRepository.delete(post);
         return getMessage("게시물이 삭제되었습니다.");
     }

--- a/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
@@ -111,6 +111,7 @@ public class PostServiceImpl implements PostService {
 
         commentRepository.deleteCommentAllByPostId(postId);
         postHeartRepository.deletePostHeartAllByPostId(postId);
+        postImageRepository.deleteAllPostImageByPostId(postId);
 
         postRepository.delete(post);
         return getMessage("게시물이 삭제되었습니다.");

--- a/src/main/java/com/project/snsserver/domain/notification/model/dto/NotificationResponse.java
+++ b/src/main/java/com/project/snsserver/domain/notification/model/dto/NotificationResponse.java
@@ -1,13 +1,12 @@
 package com.project.snsserver.domain.notification.model.dto;
 
 import com.project.snsserver.domain.notification.model.entity.Notification;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -21,7 +20,7 @@ public class NotificationResponse {
 
     private String content;
 
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
 
     public static NotificationResponse fromEntity(Notification notification) {
@@ -29,7 +28,7 @@ public class NotificationResponse {
                 .notificationId(notification.getId())
                 .type(notification.getNotificationType().name())
                 .content(notification.getContent())
-                .createdAt(Timestamp.valueOf(notification.getCreatedAt()))
+                .createdAt(notification.getCreatedAt())
                 .build();
     }
 }

--- a/src/test/java/com/project/snsserver/domain/board/service/PostServiceTest.java
+++ b/src/test/java/com/project/snsserver/domain/board/service/PostServiceTest.java
@@ -6,6 +6,8 @@ import com.project.snsserver.domain.board.model.dto.EditPostResponse;
 import com.project.snsserver.domain.board.model.dto.PostImageResponse;
 import com.project.snsserver.domain.board.model.entity.Post;
 import com.project.snsserver.domain.board.model.entity.PostImage;
+import com.project.snsserver.domain.board.repository.jpa.CommentRepository;
+import com.project.snsserver.domain.board.repository.jpa.PostHeartRepository;
 import com.project.snsserver.domain.board.repository.jpa.PostImageRepository;
 import com.project.snsserver.domain.board.repository.jpa.PostRepository;
 import com.project.snsserver.domain.member.model.entity.Member;
@@ -39,6 +41,12 @@ class PostServiceTest {
 
     @Mock
     private PostImageRepository postImageRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostHeartRepository postHeartRepository;
 
     @Mock
     private AwsS3Service awsS3Service;
@@ -189,6 +197,9 @@ class PostServiceTest {
                 .build();
 
         given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+        given(commentRepository.deleteCommentAllByPostId(anyLong())).willReturn(1L);
+        given(postHeartRepository.deletePostHeartAllByPostId(anyLong())).willReturn(1L);
+        given(postImageRepository.deleteAllPostImageByPostId(anyLong())).willReturn(1L);
 
         ArgumentCaptor<Post> postCaptor = ArgumentCaptor.forClass(Post.class);
 


### PR DESCRIPTION
- 게시물 삭제 시 좋아요 및 이미지 각각 delete 쿼리 한 번만 날아가도록 함
- 게시물 조회 시 댓글 개수는 left join을 통해 좋아요 개수는 sub query를 통해 가져옴