### PR TITLE
Feat-9 해시태그

### DIFF
--- a/src/main/java/com/project/snsserver/domain/board/controller/PostController.java
+++ b/src/main/java/com/project/snsserver/domain/board/controller/PostController.java
@@ -109,4 +109,15 @@ public class PostController {
         PostDetailResponse response = postService.getPostDetail(postId);
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 글 해시태그 목록 조회
+     */
+    @Operation(summary = "글 해시태그 목록 조회")
+    @GetMapping("/{postId}/tags")
+    public ResponseEntity<List<PostHashtagResponse>> getPostHashtagsByPost(@PathVariable Long postId) {
+
+        List<PostHashtagResponse> response = postService.getPostHashtags(postId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/board/controller/PostController.java
+++ b/src/main/java/com/project/snsserver/domain/board/controller/PostController.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/posts")
 @RequiredArgsConstructor
-@Tag(name = "게시판", description = "게시판 API Document - 게시물")
+@Tag(name = "게시물", description = "게시판 API Document - 게시물")
 public class PostController {
 
     private final PostService postService;
@@ -118,6 +118,19 @@ public class PostController {
     public ResponseEntity<List<PostHashtagResponse>> getPostHashtagsByPost(@PathVariable Long postId) {
 
         List<PostHashtagResponse> response = postService.getPostHashtags(postId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 해시태그에 따른 글 목록 조회
+     */
+    @Operation(summary = "해시태그에 따른 글 목록 조회")
+    @GetMapping("/search")
+    public ResponseEntity<Slice<PostResponse>> getPostsByHashtag(@RequestParam(required = false) Long postLastId,
+                                               @RequestParam String tag,
+                                               @PageableDefault Pageable pageable) {
+
+        Slice<PostResponse> response = postService.getPostsByHashtag(postLastId, tag, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/model/dto/EditPostRequest.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/dto/EditPostRequest.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.Set;
 
 @Getter
 @Builder
@@ -18,4 +20,7 @@ public class EditPostRequest {
 
     @NotBlank(message = "내용을 입력해주세요.")
     private String content;
+
+    @Size(max = 5, message = "해시태그는 최대 5개까지 입력 가능합니다.")
+    private Set<String> tagNames;
 }

--- a/src/main/java/com/project/snsserver/domain/board/model/dto/PostHashtagResponse.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/dto/PostHashtagResponse.java
@@ -1,0 +1,15 @@
+package com.project.snsserver.domain.board.model.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostHashtagResponse {
+
+    private Long postHashtagId;
+
+    private String tagName;
+}

--- a/src/main/java/com/project/snsserver/domain/board/model/entity/Hashtag.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/entity/Hashtag.java
@@ -1,0 +1,22 @@
+package com.project.snsserver.domain.board.model.entity;
+
+import com.project.snsserver.global.entity.BaseCreatedTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hashtag extends BaseCreatedTimeEntity {
+
+    @Id
+    @Column(name = "hashtag_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String name;
+}

--- a/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
@@ -42,6 +42,9 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
     private List<PostHeart> hearts = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostHashtag> hashtags = new ArrayList<>();
 
     public void update(String title, String content) {
         this.title = title;

--- a/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
@@ -43,7 +43,7 @@ public class Post extends BaseTimeEntity {
     private List<PostHeart> hearts = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
     private List<PostHashtag> hashtags = new ArrayList<>();
 
     public void update(String title, String content) {

--- a/src/main/java/com/project/snsserver/domain/board/model/entity/PostHashtag.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/entity/PostHashtag.java
@@ -1,0 +1,27 @@
+package com.project.snsserver.domain.board.model.entity;
+
+import com.project.snsserver.global.entity.BaseCreatedTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostHashtag extends BaseCreatedTimeEntity {
+
+    @Id
+    @Column(name = "post_hashtag_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", updatable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id", updatable = false)
+    private Hashtag hashtag;
+}

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHashtagRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHashtagRepository.java
@@ -1,0 +1,10 @@
+package com.project.snsserver.domain.board.repository.jpa;
+
+import com.project.snsserver.domain.board.model.dto.PostHashtagResponse;
+
+import java.util.List;
+
+public interface CustomPostHashtagRepository {
+
+    List<PostHashtagResponse> findAllPostHashtagByPostId(Long postId);
+}

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHashtagRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHashtagRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface CustomPostHashtagRepository {
 
     List<PostHashtagResponse> findAllPostHashtagByPostId(Long postId);
+
+    Long deletePostHashtagAllByPostId(Long postId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostRepository.java
@@ -11,4 +11,6 @@ public interface CustomPostRepository {
     Slice<PostResponse> findAllPostsWithCommentCntAndHeartCnt(Long lastPostId, Pageable pageable);
 
     PostDetailResponse findPostDetailByPostId(Long postId);
+
+    Slice<PostResponse> findAllPostsByHashtag(Long lastPostId, String name, Pageable pageable);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/HashtagRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/HashtagRepository.java
@@ -1,0 +1,11 @@
+package com.project.snsserver.domain.board.repository.jpa;
+
+import com.project.snsserver.domain.board.model.entity.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+     Optional<Hashtag> findByName(String name);
+}

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/PostHashtagRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/PostHashtagRepository.java
@@ -3,5 +3,5 @@ package com.project.snsserver.domain.board.repository.jpa;
 import com.project.snsserver.domain.board.model.entity.PostHashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long>, CustomPostHashtagRepository {
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/PostHashtagRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/PostHashtagRepository.java
@@ -1,0 +1,7 @@
+package com.project.snsserver.domain.board.repository.jpa;
+
+import com.project.snsserver.domain.board.model.entity.PostHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+}

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHashtagRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHashtagRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.project.snsserver.domain.board.repository.jpa.impl;
+
+import com.project.snsserver.domain.board.model.dto.PostHashtagResponse;
+import com.project.snsserver.domain.board.repository.jpa.CustomPostHashtagRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.project.snsserver.domain.board.model.entity.QHashtag.hashtag;
+import static com.project.snsserver.domain.board.model.entity.QPostHashtag.postHashtag;
+import static com.querydsl.core.types.Projections.bean;
+
+@RequiredArgsConstructor
+public class CustomPostHashtagRepositoryImpl implements CustomPostHashtagRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<PostHashtagResponse> findAllPostHashtagByPostId(Long postId) {
+
+        return queryFactory
+                .select(
+                        bean(PostHashtagResponse.class,
+                                postHashtag.id.as("postHashtagId"),
+                                hashtag.name.as("tagName")
+                        )
+                )
+                .from(postHashtag)
+                .leftJoin(postHashtag.hashtag, hashtag)
+                .where(postHashtag.post.id.eq(postId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHashtagRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHashtagRepositoryImpl.java
@@ -30,4 +30,11 @@ public class CustomPostHashtagRepositoryImpl implements CustomPostHashtagReposit
                 .where(postHashtag.post.id.eq(postId))
                 .fetch();
     }
+
+    @Override
+    public Long deletePostHashtagAllByPostId(Long postId) {
+        return queryFactory.delete(postHashtag)
+                .where(postHashtag.post.id.eq(postId))
+                .execute();
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/board/service/HashtagService.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/HashtagService.java
@@ -1,0 +1,11 @@
+package com.project.snsserver.domain.board.service;
+
+import com.project.snsserver.domain.board.model.entity.Hashtag;
+
+public interface HashtagService {
+
+    /**
+     * 기존에 존재하는 해시태그인지 확인 후 없으면 저장
+     */
+    Hashtag createHashtag(String tagName);
+}

--- a/src/main/java/com/project/snsserver/domain/board/service/HashtagServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/HashtagServiceImpl.java
@@ -1,0 +1,31 @@
+package com.project.snsserver.domain.board.service;
+
+import com.project.snsserver.domain.board.model.entity.Hashtag;
+import com.project.snsserver.domain.board.repository.jpa.HashtagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class HashtagServiceImpl implements HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    @Override
+    @Transactional
+    public Hashtag createHashtag(String tagName) {
+
+        Optional<Hashtag> optional
+                = hashtagRepository.findByName(tagName);
+
+        if (optional.isEmpty()) {
+            return hashtagRepository.save(Hashtag.builder().name(tagName).build());
+        }
+
+        return optional.get();
+    }
+}
+

--- a/src/main/java/com/project/snsserver/domain/board/service/PostHashtagService.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostHashtagService.java
@@ -1,0 +1,13 @@
+package com.project.snsserver.domain.board.service;
+
+import com.project.snsserver.domain.board.model.entity.Post;
+
+import java.util.Set;
+
+public interface PostHashtagService {
+
+    /**
+     * hashtag - post hashtag 연결
+     */
+    void createPostHashtag(Post post, Set<String> tagNames);
+}

--- a/src/main/java/com/project/snsserver/domain/board/service/PostHashtagServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostHashtagServiceImpl.java
@@ -1,0 +1,40 @@
+package com.project.snsserver.domain.board.service;
+
+import com.project.snsserver.domain.board.model.entity.Hashtag;
+import com.project.snsserver.domain.board.model.entity.Post;
+import com.project.snsserver.domain.board.model.entity.PostHashtag;
+import com.project.snsserver.domain.board.repository.jpa.PostHashtagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class PostHashtagServiceImpl implements PostHashtagService {
+
+    private final HashtagService hashtagService;
+    private final PostHashtagRepository postHashtagRepository;
+
+    @Override
+    @Transactional
+    public void createPostHashtag(Post post, Set<String> tagNames) {
+
+        if(tagNames.isEmpty()) return;
+
+        tagNames.stream()
+                .map(hashtagService::createHashtag)
+                .forEach(hashtag -> mapToPostHashtags(post, hashtag));
+    }
+
+    private void mapToPostHashtags(Post post, Hashtag hashtag) {
+
+        PostHashtag postHashtag = PostHashtag.builder()
+                .post(post)
+                .hashtag(hashtag)
+                .build();
+
+        postHashtagRepository.save(postHashtag);
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/board/service/PostService.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostService.java
@@ -50,4 +50,9 @@ public interface PostService {
      * 게시물의 해시태그 목록 조회
      */
     List<PostHashtagResponse> getPostHashtags(Long postId);
+
+    /**
+     * 해시태그에 따른 글 목록 조회
+     */
+    Slice<PostResponse> getPostsByHashtag(Long lastPostId, String tag, Pageable pageable);
 }

--- a/src/main/java/com/project/snsserver/domain/board/service/PostService.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostService.java
@@ -45,4 +45,9 @@ public interface PostService {
      * 게시물 상세 조회
      */
     PostDetailResponse getPostDetail(Long postId);
+
+    /**
+     * 게시물의 해시태그 목록 조회
+     */
+    List<PostHashtagResponse> getPostHashtags(Long postId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
@@ -111,6 +111,7 @@ public class PostServiceImpl implements PostService {
         commentRepository.deleteCommentAllByPostId(postId);
         postHeartRepository.deletePostHeartAllByPostId(postId);
         postImageRepository.deleteAllPostImageByPostId(postId);
+        postHashtagRepository.deletePostHashtagAllByPostId(postId);
 
         postRepository.delete(post);
         return getMessage("게시물이 삭제되었습니다.");

--- a/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
@@ -177,6 +177,12 @@ public class PostServiceImpl implements PostService {
         return postHashtagRepository.findAllPostHashtagByPostId(post.getId());
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Slice<PostResponse> getPostsByHashtag(Long lastPostId, String tag, Pageable pageable) {
+        return postRepository.findAllPostsByHashtag(lastPostId, tag, pageable);
+    }
+
     private static Map<String, String> getMessage(String message) {
         Map<String, String> result = new HashMap<>();
         result.put("result", message);

--- a/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
@@ -4,10 +4,7 @@ import com.project.snsserver.domain.awss3.service.AwsS3Service;
 import com.project.snsserver.domain.board.model.dto.*;
 import com.project.snsserver.domain.board.model.entity.Post;
 import com.project.snsserver.domain.board.model.entity.PostImage;
-import com.project.snsserver.domain.board.repository.jpa.CommentRepository;
-import com.project.snsserver.domain.board.repository.jpa.PostHeartRepository;
-import com.project.snsserver.domain.board.repository.jpa.PostImageRepository;
-import com.project.snsserver.domain.board.repository.jpa.PostRepository;
+import com.project.snsserver.domain.board.repository.jpa.*;
 import com.project.snsserver.domain.member.model.entity.Member;
 import com.project.snsserver.global.error.exception.BoardException;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +30,7 @@ public class PostServiceImpl implements PostService {
     private final PostImageRepository postImageRepository;
     private final CommentRepository commentRepository;
     private final PostHeartRepository postHeartRepository;
+    private final PostHashtagService postHashtagService;
 
     @Override
     @Transactional
@@ -66,6 +64,9 @@ public class PostServiceImpl implements PostService {
                 postImageRepository.save(image);
                 postImgResponse.add(PostImageResponse.fromEntity(image));
             }
+        }
+        if(!Objects.isNull(request.getTagNames())) {
+            postHashtagService.createPostHashtag(post, request.getTagNames());
         }
         return EditPostResponse.fromEntity(post, postImgResponse);
     }

--- a/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
@@ -31,6 +31,7 @@ public class PostServiceImpl implements PostService {
     private final CommentRepository commentRepository;
     private final PostHeartRepository postHeartRepository;
     private final PostHashtagService postHashtagService;
+    private final PostHashtagRepository postHashtagRepository;
 
     @Override
     @Transactional
@@ -163,6 +164,16 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new BoardException(POST_NOT_FOUND));
 
         return postRepository.findPostDetailByPostId(post.getId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PostHashtagResponse> getPostHashtags(Long postId) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new BoardException(POST_NOT_FOUND));
+
+        return postHashtagRepository.findAllPostHashtagByPostId(post.getId());
     }
 
     private static Map<String, String> getMessage(String message) {


### PR DESCRIPTION
- 게시물 작성 시 해시태그 추가 (최대 5개)
- 게시물 상세 조회 시 복수의 해시태그 조회는 별도의 api로 가능
- 해시태그 검색 시 해당 해시태그를 가지고 있는 글 목록 조회

📌 **추후 개선**
게시물 수정 시 해시태그 수정은 어떻게 처리할 지 고민중