### PR TITLE
Fix-1 : 게시물 상세 조회 오류 

### DIFF
--- a/src/main/java/com/project/snsserver/domain/board/model/dto/PostDetailResponse.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/dto/PostDetailResponse.java
@@ -27,4 +27,17 @@ public class PostDetailResponse {
     private Long heartCnt;
 
     private LocalDateTime createdAt;
+
+    public static PostDetailResponse from (PostResponse post, List<PostImageResponse> images) {
+        return PostDetailResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .nickname(post.getNickname())
+                .createdAt(post.getCreatedAt())
+                .commentCnt(post.getCommentCnt())
+                .heartCnt(post.getHeartCnt())
+                .postImages(images)
+                .build();
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostImageRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostImageRepository.java
@@ -1,6 +1,12 @@
 package com.project.snsserver.domain.board.repository.jpa;
 
+import com.project.snsserver.domain.board.model.dto.PostImageResponse;
+
+import java.util.List;
+
 public interface CustomPostImageRepository {
 
     Long deleteAllPostImageByPostId(Long postId);
+
+    List<PostImageResponse> findAllPostImageByPostId(Long postId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostRepository.java
@@ -1,6 +1,5 @@
 package com.project.snsserver.domain.board.repository.jpa;
 
-import com.project.snsserver.domain.board.model.dto.PostDetailResponse;
 import com.project.snsserver.domain.board.model.dto.PostResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -10,7 +9,7 @@ public interface CustomPostRepository {
 
     Slice<PostResponse> findAllPostsWithCommentCntAndHeartCnt(Long lastPostId, Pageable pageable);
 
-    PostDetailResponse findPostDetailByPostId(Long postId);
+    PostResponse findPostByPostId(Long postId);
 
     Slice<PostResponse> findAllPostsByHashtag(Long lastPostId, String name, Pageable pageable);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostImageRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostImageRepositoryImpl.java
@@ -1,10 +1,14 @@
 package com.project.snsserver.domain.board.repository.jpa.impl;
 
+import com.project.snsserver.domain.board.model.dto.PostImageResponse;
 import com.project.snsserver.domain.board.repository.jpa.CustomPostImageRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 import static com.project.snsserver.domain.board.model.entity.QPostImage.postImage;
+import static com.querydsl.core.types.Projections.bean;
 
 @RequiredArgsConstructor
 public class CustomPostImageRepositoryImpl implements CustomPostImageRepository {
@@ -17,5 +21,19 @@ public class CustomPostImageRepositoryImpl implements CustomPostImageRepository 
         return queryFactory.delete(postImage)
                 .where(postImage.post.id.eq(postId))
                 .execute();
+    }
+
+    @Override
+    public List<PostImageResponse> findAllPostImageByPostId(Long postId) {
+        return queryFactory.select(
+                        bean(PostImageResponse.class,
+                                postImage.id.as("postImageId"),
+                                postImage.postImageUrl.as("postImageUrl"),
+                                postImage.createdAt.as("createdAt")
+                        )
+                )
+                .from(postImage)
+                .where(postImage.post.id.eq(postId))
+                .fetch();
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/service/PostServiceImpl.java
@@ -164,7 +164,13 @@ public class PostServiceImpl implements PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BoardException(POST_NOT_FOUND));
 
-        return postRepository.findPostDetailByPostId(post.getId());
+        PostResponse postResponse
+                = postRepository.findPostByPostId(post.getId());
+
+        List<PostImageResponse> postImageResponse
+                = postImageRepository.findAllPostImageByPostId(post.getId());
+
+        return PostDetailResponse.from(postResponse, postImageResponse);
     }
 
     @Override


### PR DESCRIPTION
게시물의 이미지가 존재하지 않는 경우 발생함
- 게시물 dto 조회와 게시물 이미지 dto 리스트 조회를 분리