### PR TITLE
Feat-10 회원 정보

### DIFF
--- a/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
+++ b/src/main/java/com/project/snsserver/domain/board/model/entity/Post.java
@@ -31,19 +31,19 @@ public class Post extends BaseTimeEntity {
     private Member member;
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "post")
     private List<PostImage> postImages = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "post")
     private List<PostHeart> hearts = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "post")
     private List<PostHashtag> hashtags = new ArrayList<>();
 
     public void update(String title, String content) {

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomCommentRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomCommentRepository.java
@@ -10,4 +10,8 @@ public interface CustomCommentRepository {
     Slice<CommentResponse> findCommentAllByPostId(Long postId, Long lastCommentId, Pageable pageable);
 
     Long deleteCommentAllByPostId(Long postId);
+
+    Long deleteCommentAllByMemberId(Long memberId);
+
+    Long deleteCommentAllInPostIdsByMemberId(Long memberId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHashtagRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHashtagRepository.java
@@ -9,4 +9,6 @@ public interface CustomPostHashtagRepository {
     List<PostHashtagResponse> findAllPostHashtagByPostId(Long postId);
 
     Long deletePostHashtagAllByPostId(Long postId);
+
+    Long deletePostHashtagAllInPostIdsByMemberId(Long memberId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHeartRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostHeartRepository.java
@@ -3,4 +3,8 @@ package com.project.snsserver.domain.board.repository.jpa;
 public interface CustomPostHeartRepository {
 
     Long deletePostHeartAllByPostId(Long postId);
+
+    Long deletePostHeartAllByMemberId(Long memberId);
+
+    Long deletePostHeartAllInPostIdsByMemberId(Long memberId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostImageRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostImageRepository.java
@@ -9,4 +9,6 @@ public interface CustomPostImageRepository {
     Long deleteAllPostImageByPostId(Long postId);
 
     List<PostImageResponse> findAllPostImageByPostId(Long postId);
+
+    Long deleteAllPostImageInPostIdsByMemberId(Long memberId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostRepository.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/CustomPostRepository.java
@@ -12,4 +12,6 @@ public interface CustomPostRepository {
     PostResponse findPostByPostId(Long postId);
 
     Slice<PostResponse> findAllPostsByHashtag(Long lastPostId, String name, Pageable pageable);
+
+    Long deleteAllPostByMemberId(Long memberId);
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomCommentRepositoryImpl.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import static com.project.snsserver.domain.board.model.entity.QComment.comment;
 import static com.project.snsserver.domain.board.model.entity.QPost.post;
 import static com.project.snsserver.domain.member.model.entity.QMember.member;
+import static com.querydsl.jpa.JPAExpressions.select;
 
 @RequiredArgsConstructor
 public class CustomCommentRepositoryImpl implements CustomCommentRepository {
@@ -49,6 +50,22 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
     public Long deleteCommentAllByPostId(Long postId) {
         return queryFactory.delete(comment)
                 .where(comment.post.id.eq(postId))
+                .execute();
+    }
+
+    @Override
+    public Long deleteCommentAllByMemberId(Long memberId) {
+        return queryFactory.delete(comment)
+                .where(comment.member.id.eq(memberId))
+                .execute();
+    }
+
+    public Long deleteCommentAllInPostIdsByMemberId(Long memberId) {
+        return queryFactory.delete(comment)
+                .where(comment.post.id.in(
+                                select(post.id).from(post).where(post.member.id.eq(memberId))
+                        )
+                )
                 .execute();
     }
 

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHashtagRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHashtagRepositoryImpl.java
@@ -8,8 +8,10 @@ import lombok.RequiredArgsConstructor;
 import java.util.List;
 
 import static com.project.snsserver.domain.board.model.entity.QHashtag.hashtag;
+import static com.project.snsserver.domain.board.model.entity.QPost.post;
 import static com.project.snsserver.domain.board.model.entity.QPostHashtag.postHashtag;
 import static com.querydsl.core.types.Projections.bean;
+import static com.querydsl.jpa.JPAExpressions.select;
 
 @RequiredArgsConstructor
 public class CustomPostHashtagRepositoryImpl implements CustomPostHashtagRepository {
@@ -35,6 +37,16 @@ public class CustomPostHashtagRepositoryImpl implements CustomPostHashtagReposit
     public Long deletePostHashtagAllByPostId(Long postId) {
         return queryFactory.delete(postHashtag)
                 .where(postHashtag.post.id.eq(postId))
+                .execute();
+    }
+
+    @Override
+    public Long deletePostHashtagAllInPostIdsByMemberId(Long memberId) {
+        return queryFactory.delete(postHashtag)
+                .where(postHashtag.post.id.in(
+                                select(post.id).from(post).where(post.member.id.eq(memberId))
+                        )
+                )
                 .execute();
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHeartRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostHeartRepositoryImpl.java
@@ -4,7 +4,9 @@ import com.project.snsserver.domain.board.repository.jpa.CustomPostHeartReposito
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import static com.project.snsserver.domain.board.model.entity.QPost.post;
 import static com.project.snsserver.domain.board.model.entity.QPostHeart.postHeart;
+import static com.querydsl.jpa.JPAExpressions.select;
 
 @RequiredArgsConstructor
 public class CustomPostHeartRepositoryImpl implements CustomPostHeartRepository {
@@ -15,6 +17,19 @@ public class CustomPostHeartRepositoryImpl implements CustomPostHeartRepository 
     public Long deletePostHeartAllByPostId(Long postId) {
         return queryFactory.delete(postHeart)
                 .where(postHeart.post.id.eq(postId))
+                .execute();
+    }
+
+    @Override
+    public Long deletePostHeartAllByMemberId(Long memberId) {
+        return queryFactory.delete(postHeart)
+                .where(postHeart.member.id.eq(memberId))
+                .execute();
+    }
+
+    public Long deletePostHeartAllInPostIdsByMemberId(Long memberId) {
+        return queryFactory.delete(postHeart)
+                .where(postHeart.post.id.in(select(post.id).from(post).where(post.member.id.eq(memberId))))
                 .execute();
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostImageRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostImageRepositoryImpl.java
@@ -7,8 +7,10 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+import static com.project.snsserver.domain.board.model.entity.QPost.post;
 import static com.project.snsserver.domain.board.model.entity.QPostImage.postImage;
 import static com.querydsl.core.types.Projections.bean;
+import static com.querydsl.jpa.JPAExpressions.select;
 
 @RequiredArgsConstructor
 public class CustomPostImageRepositoryImpl implements CustomPostImageRepository {
@@ -35,5 +37,15 @@ public class CustomPostImageRepositoryImpl implements CustomPostImageRepository 
                 .from(postImage)
                 .where(postImage.post.id.eq(postId))
                 .fetch();
+    }
+
+    @Override
+    public Long deleteAllPostImageInPostIdsByMemberId(Long memberId) {
+        return queryFactory.delete(postImage)
+                .where(postImage.post.id.in(
+                                select(post.id).from(post).where(post.member.id.eq(memberId))
+                        )
+                )
+                .execute();
     }
 }

--- a/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/board/repository/jpa/impl/CustomPostRepositoryImpl.java
@@ -112,6 +112,13 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
         return checkLastPage(pageable, postsByHashtag);
     }
 
+    @Override
+    public Long deleteAllPostByMemberId(Long memberId) {
+        return queryFactory.delete(post)
+                .where(post.member.id.eq(memberId))
+                .execute();
+    }
+
     private BooleanExpression lastPostId(Long lastPostId) {
         if (lastPostId == null) {
             return null;

--- a/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
@@ -136,4 +136,15 @@ public class MemberController {
         Map<String, String> response = memberService.updateNickname(request, userDetails.getUsername());
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 회원 탈퇴
+     */
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/info")
+    public ResponseEntity<Map<String, String>> withdraw(@RequestBody @Valid WithdrawRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Map<String, String> response = memberService.withdraw(request, userDetails.getMember());
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
@@ -138,6 +138,18 @@ public class MemberController {
     }
 
     /**
+     * 회원 프로필 이미지 변경
+     */
+    @Operation(summary = "회원 프로필 이미지 변경")
+    @PatchMapping("/info/profile")
+    public ResponseEntity<Map<String, String>> updateProfileImg(@RequestPart(value = "image") MultipartFile file,
+
+                                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Map<String, String> response = memberService.updateProfileImg(file, userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
      * 회원 탈퇴
      */
     @Operation(summary = "회원 탈퇴")

--- a/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
@@ -124,4 +124,16 @@ public class MemberController {
         Map<String, String> response = memberService.updatePassword(request, userDetails.getUsername());
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 회원 닉네임 변경
+     */
+    @Operation(summary = "회원 닉네임 변경")
+    @PatchMapping("/info/nickname")
+    public ResponseEntity<Map<String, String>> updateNickname(@RequestBody @Valid UpdateNicknameRequest request,
+                                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Map<String, String> response = memberService.updateNickname(request, userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
@@ -112,4 +112,16 @@ public class MemberController {
         Map<String, String> response = memberService.logout(request, userDetails.getUsername());
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 회원 비밀번호 변경
+     */
+    @Operation(summary = "회원 비밀번호 변경")
+    @PatchMapping("/info/password")
+    public ResponseEntity<Map<String, String>> updatePassword(@RequestBody @Valid UpdatePasswordRequest request,
+                                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Map<String, String> response = memberService.updatePassword(request, userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/snsserver/domain/member/controller/MemberController.java
@@ -147,4 +147,15 @@ public class MemberController {
         Map<String, String> response = memberService.withdraw(request, userDetails.getMember());
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 회원 정보 조회
+     */
+    @Operation(summary = "회원 정보 조회")
+    @GetMapping("/info")
+    public ResponseEntity<MemberDetailResponse> getMemberDetail(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        MemberDetailResponse response = memberService.getMemberDetail(userDetails.getMember());
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/MemberDetailResponse.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/MemberDetailResponse.java
@@ -1,0 +1,33 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import com.project.snsserver.domain.member.type.Gender;
+import com.project.snsserver.domain.member.type.MemberRole;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberDetailResponse {
+
+    private Long memberId;
+
+    private String email;
+
+    private String nickname;
+
+    private Gender gender;
+
+    private MemberRole role;
+
+    private String profileImgUrl;
+
+    private LocalDateTime createdAt; // 가입일
+
+    private Long totalPostCnt; // 작성한 게시물 개수
+
+    private Long totalPostHeartCnt; // 좋아요 누른 게시물 개수
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/UpdateNicknameRequest.java
@@ -1,0 +1,20 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateNicknameRequest {
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(min = 2, max = 10, message = "닉네임은 최소 2자, 최대 10자까지 가능합니다")
+    private String nickname;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/UpdatePasswordRequest.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/UpdatePasswordRequest.java
@@ -1,0 +1,24 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdatePasswordRequest {
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$",
+            message = "비밀번호는 숫자를 포함한 영문자 최소 8자, 최대 20자까지 가능합니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인을 입력해주세요.")
+    private String passwordCheck;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/dto/WithdrawRequest.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/dto/WithdrawRequest.java
@@ -1,0 +1,18 @@
+package com.project.snsserver.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class WithdrawRequest {
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/project/snsserver/domain/member/model/entity/Member.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/entity/Member.java
@@ -42,4 +42,8 @@ public class Member extends BaseTimeEntity {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/member/model/entity/Member.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/entity/Member.java
@@ -38,4 +38,8 @@ public class Member extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/member/model/entity/Member.java
+++ b/src/main/java/com/project/snsserver/domain/member/model/entity/Member.java
@@ -46,4 +46,8 @@ public class Member extends BaseTimeEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updateProfileImg(String profileImgUrl) {
+        this.profileImgUrl = profileImgUrl;
+    }
 }

--- a/src/main/java/com/project/snsserver/domain/member/repository/jpa/CustomMemberRepository.java
+++ b/src/main/java/com/project/snsserver/domain/member/repository/jpa/CustomMemberRepository.java
@@ -1,0 +1,8 @@
+package com.project.snsserver.domain.member.repository.jpa;
+
+import com.project.snsserver.domain.member.model.dto.MemberDetailResponse;
+
+public interface CustomMemberRepository {
+
+    MemberDetailResponse findMemberDetailByMemberId(Long memberId);
+}

--- a/src/main/java/com/project/snsserver/domain/member/repository/jpa/MemberRepository.java
+++ b/src/main/java/com/project/snsserver/domain/member/repository/jpa/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, CustomMemberRepository {
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/com/project/snsserver/domain/member/repository/jpa/impl/CustomMemberRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/member/repository/jpa/impl/CustomMemberRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.project.snsserver.domain.member.repository.jpa.impl;
+
+import com.project.snsserver.domain.member.model.dto.MemberDetailResponse;
+import com.project.snsserver.domain.member.repository.jpa.CustomMemberRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.project.snsserver.domain.board.model.entity.QPost.post;
+import static com.project.snsserver.domain.board.model.entity.QPostHeart.postHeart;
+import static com.project.snsserver.domain.member.model.entity.QMember.member;
+import static com.querydsl.core.types.Projections.bean;
+import static com.querydsl.core.types.ExpressionUtils.as;
+import static com.querydsl.jpa.JPAExpressions.select;
+
+@RequiredArgsConstructor
+public class CustomMemberRepositoryImpl implements CustomMemberRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public MemberDetailResponse findMemberDetailByMemberId(Long memberId) {
+
+        return queryFactory.select(
+                bean(MemberDetailResponse.class,
+                        member.id.as("memberId"),
+                        member.email.as("email"),
+                        member.nickname.as("nickname"),
+                        member.gender.as("gender"),
+                        member.role.as("role"),
+                        member.profileImgUrl.as("profileImgUrl"),
+                        member.createdAt.as("createdAt"),
+                        as(select(post.id.count()).from(post)
+                                        .where(post.member.id.eq(memberId)),
+                                "totalPostCnt"),
+                        as(select(postHeart.id.count()).from(postHeart)
+                                        .where(postHeart.member.id.eq(memberId)),
+                                "totalPostHeartCnt")
+                        )
+        )
+                .from(member)
+                .where(member.id.eq(memberId))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
@@ -62,4 +62,9 @@ public interface MemberService {
      * 회원 탈퇴
      */
     Map<String, String> withdraw(WithdrawRequest request, Member member);
+
+    /**
+     * 회원 정보 조회
+     */
+    MemberDetailResponse getMemberDetail(Member member);
 }

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.project.snsserver.domain.member.service;
 
 import com.project.snsserver.domain.member.model.dto.*;
+import com.project.snsserver.domain.member.model.entity.Member;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
@@ -56,4 +57,9 @@ public interface MemberService {
      * 회원 닉네임 수정
      */
     Map<String, String> updateNickname(UpdateNicknameRequest request, String email);
+
+    /**
+     * 회원 탈퇴
+     */
+    Map<String, String> withdraw(WithdrawRequest request, Member member);
 }

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
@@ -51,4 +51,9 @@ public interface MemberService {
      * 회원 비밀번호 수정
      */
     Map<String, String> updatePassword(UpdatePasswordRequest request, String email);
+
+    /**
+     * 회원 닉네임 수정
+     */
+    Map<String, String> updateNickname(UpdateNicknameRequest request, String email);
 }

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
@@ -59,6 +59,11 @@ public interface MemberService {
     Map<String, String> updateNickname(UpdateNicknameRequest request, String email);
 
     /**
+     * 회원 프로필 이미지 수정
+     */
+    Map<String, String> updateProfileImg(MultipartFile file, String email);
+
+    /**
      * 회원 탈퇴
      */
     Map<String, String> withdraw(WithdrawRequest request, Member member);

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberService.java
@@ -46,4 +46,9 @@ public interface MemberService {
      * 회원 로그아웃
      */
     Map<String, String> logout(LogoutRequest request, String email);
+
+    /**
+     * 회원 비밀번호 수정
+     */
+    Map<String, String> updatePassword(UpdatePasswordRequest request, String email);
 }

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
@@ -275,6 +275,12 @@ public class MemberServiceImpl implements MemberService {
         return getMessage("회원 탈퇴가 완료되었습니다.");
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public MemberDetailResponse getMemberDetail(Member member) {
+        return memberRepository.findMemberDetailByMemberId(member.getId());
+    }
+
 
     private static Map<String, String> getMessage(String message) {
         Map<String, String> result = new HashMap<>();

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
@@ -220,6 +220,21 @@ public class MemberServiceImpl implements MemberService {
         return getMessage("비밀번호 변경이 완료되었습니다.");
     }
 
+    @Override
+    @Transactional
+    public Map<String, String> updateNickname(UpdateNicknameRequest request, String email) {
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        if(memberRepository.existsByNickname(request.getNickname())) {
+            throw new MemberException(DUPLICATED_NICKNAME);
+        }
+
+        member.updateNickname(request.getNickname());
+        return getMessage("닉네임 변경이 완료되었습니다.");
+    }
+
 
     private static Map<String, String> getMessage(String message) {
         Map<String, String> result = new HashMap<>();

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
@@ -245,6 +245,20 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
+    public Map<String, String> updateProfileImg(MultipartFile file, String email) {
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        String newProfileImgUrl = awsS3Service.uploadFile(file, DIR);
+        awsS3Service.deleteFile(member.getProfileImgUrl(), DIR);
+
+        member.updateProfileImg(newProfileImgUrl);
+        return getMessage("프로필 이미지 변경이 완료되었습니다.");
+    }
+
+    @Override
+    @Transactional
     public Map<String, String> withdraw(WithdrawRequest request, Member member) {
 
         if(!passwordEncoder.matches(request.getPassword(), member.getPassword())) {

--- a/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/project/snsserver/domain/member/service/MemberServiceImpl.java
@@ -205,6 +205,21 @@ public class MemberServiceImpl implements MemberService {
         return getMessage("로그아웃에 성공하였습니다.");
     }
 
+    @Override
+    @Transactional
+    public Map<String, String> updatePassword(UpdatePasswordRequest request, String email) {
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() ->  new MemberException(MEMBER_NOT_FOUND));
+
+        if(!Objects.equals(request.getPassword(), request.getPasswordCheck())) {
+            throw new MemberException(INCORRECT_PASSWORD_CHECK);
+        }
+
+        member.updatePassword(passwordEncoder.encode(request.getPassword()));
+        return getMessage("비밀번호 변경이 완료되었습니다.");
+    }
+
 
     private static Map<String, String> getMessage(String message) {
         Map<String, String> result = new HashMap<>();

--- a/src/main/java/com/project/snsserver/domain/notification/repository/jpa/CustomNotificationRepository.java
+++ b/src/main/java/com/project/snsserver/domain/notification/repository/jpa/CustomNotificationRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.domain.Slice;
 public interface CustomNotificationRepository {
 
     Slice<NotificationResponse> findNotificationAllByMemberId(Long memberId, Long lastNotificationId, Pageable pageable);
+
+    Long deleteNotificationAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/project/snsserver/domain/notification/repository/jpa/CustomNotificationRepositoryImpl.java
+++ b/src/main/java/com/project/snsserver/domain/notification/repository/jpa/CustomNotificationRepositoryImpl.java
@@ -39,6 +39,13 @@ public class CustomNotificationRepositoryImpl implements CustomNotificationRepos
         return checkLastPage(pageable, notifications);
     }
 
+    @Override
+    public Long deleteNotificationAllByMemberId(Long memberId) {
+        return queryFactory.delete(notification)
+                .where(notification.member.id.eq(memberId))
+                .execute();
+    }
+
     private BooleanExpression lastNotificationId(Long lastNotificationId) {
         if(lastNotificationId == null) {
             return null;

--- a/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
+++ b/src/main/java/com/project/snsserver/global/error/type/MemberErrorCode.java
@@ -20,7 +20,9 @@ public enum MemberErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E106", "존재하지 않는 회원입니다."),
     FAIL_TO_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "E107", "사용자 인증에 실패하였습니다."),
     FAIL_TO_AUTHORIZATION(HttpStatus.FORBIDDEN, "E108", "사용자 권한이 없습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "E109", "refresh token이 유효하지 않습니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "E109", "refresh token이 유효하지 않습니다."),
+    FAIL_TO_WITHDRAWAL(HttpStatus.BAD_REQUEST, "E110", "비밀번호 입력이 올바르지 않아 탈퇴가 불가능합니다.");
+
     private final HttpStatus status;
     private final String code;
     private final String message;


### PR DESCRIPTION
- 회원 탈퇴
탈퇴 시 작성된 댓글, 게시물과 등록된 좋아요는 모두 삭제 처리
삭제될 게시물에 달린 댓글과 좋아요 또한 삭제

- 회원 정보 수정
프로필 이미지 수정 시 업로드 된 기존의 프로필 이미지  aws s3에서 삭제

- 회원 정보 조회
기본적인 정보 + 회원이 작성한 게시물의 개수와 좋아요 누른 개수도 반환

📌 **추후 개선**
회원 탈퇴 처리 시 hard delete vs soft delete (현재는 hard delete)

_**반성 : jpa cascade  무분별하게 사용하지 말기.... ㅠㅠ (지금 다 삭제한 상태 )**_
